### PR TITLE
Update xarray version to 2023.10 and Add Support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version"]
 
 dependencies = [
   "numpy", 
-  "xarray>2023.10.0", 
+  "xarray>=2023.10.0", 
   "cf_xarray", 
   "dask[complete]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,11 @@ classifiers = [
 
 dynamic = ["version"]
 
-dependencies = ["numpy", "xarray", "cf_xarray", "dask[complete]"]
+dependencies = [
+  "numpy", 
+  "xarray>2023.10.0", 
+  "cf_xarray", 
+  "dask[complete]"]
 
 [project.optional-dependencies]
 dev = [

--- a/xarray_subset_grid/accessor.py
+++ b/xarray_subset_grid/accessor.py
@@ -1,7 +1,7 @@
-from typing import Optional
+from typing import Optional, Union
 
+import numpy as np
 import xarray as xr
-from numpy import ndarray
 
 from xarray_subset_grid.grid import Grid
 from xarray_subset_grid.grids import SGrid, UGrid
@@ -87,7 +87,7 @@ class GridDatasetAccessor:
         return self._ds
 
     def subset_polygon(
-        self, polygon: list[tuple[float, float]] | ndarray
+        self, polygon: Union[list[tuple[float, float]], np.ndarray]
     ) -> Optional[xr.Dataset]:
         """Subset the dataset to the grid.
 

--- a/xarray_subset_grid/grid.py
+++ b/xarray_subset_grid/grid.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from typing import Union
 
 import numpy as np
 import xarray as xr
-from numpy import ndarray
 
 
 class Grid(ABC):
@@ -47,7 +47,7 @@ class Grid(ABC):
 
     @abstractmethod
     def subset_polygon(
-        self, ds: xr.Dataset, polygon: list[tuple[float, float]] | ndarray
+        self, ds: xr.Dataset, polygon: Union[list[tuple[float, float]], np.ndarray]
     ) -> xr.Dataset:
         """Subset the dataset to the grid
         :param ds: The dataset to subset

--- a/xarray_subset_grid/grids/sgrid.py
+++ b/xarray_subset_grid/grids/sgrid.py
@@ -1,6 +1,7 @@
+from typing import Union
+
 import numpy as np
 import xarray as xr
-from numpy import ndarray
 
 from xarray_subset_grid.grid import Grid
 from xarray_subset_grid.utils import normalize_polygon_x_coords, ray_tracing_numpy
@@ -55,7 +56,7 @@ class SGrid(Grid):
         return [var for var in ds.data_vars if not set(ds[var].dims).isdisjoint(dims)]
 
     def subset_polygon(
-        self, ds: xr.Dataset, polygon: list[tuple[float, float]] | ndarray
+        self, ds: xr.Dataset, polygon: Union[list[tuple[float, float]], np.ndarray]
     ) -> xr.Dataset:
         """Subset the dataset to the grid
         :param ds: The dataset to subset
@@ -94,9 +95,7 @@ class SGrid(Grid):
             # to match the original dimension shape
             x = np.array(lon.flat)
             polygon = normalize_polygon_x_coords(x, polygon)
-            polygon_mask = ray_tracing_numpy(x, lat.flat, polygon).reshape(
-                lon.shape
-            )
+            polygon_mask = ray_tracing_numpy(x, lat.flat, polygon).reshape(lon.shape)
 
             # Adjust the mask to only mask the rows and columns that are completely
             # outside the polygon. If the row and column both touch the target polygon
@@ -117,7 +116,9 @@ class SGrid(Grid):
             )
 
             # Now we can use the mask to subset the data
-            ds_subset = ds_subset[vars].where(ds_subset.subset_mask, drop=True).drop_encoding()
+            ds_subset = (
+                ds_subset[vars].where(ds_subset.subset_mask, drop=True).drop_encoding()
+            )
 
             # Add the subsetted dataset to the list for merging
             ds_out.append(ds_subset)

--- a/xarray_subset_grid/grids/ugrid.py
+++ b/xarray_subset_grid/grids/ugrid.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 import xarray as xr
 
@@ -85,7 +87,7 @@ class UGrid(Grid):
         return [var for var in ds.data_vars if not set(ds[var].dims).isdisjoint(dims)]
 
     def subset_polygon(
-        self, ds: xr.Dataset, polygon: list[tuple[float, float]] | np.ndarray
+        self, ds: xr.Dataset, polygon: Union[list[tuple[float, float]], np.ndarray]
     ) -> xr.Dataset:
         """Subset the dataset to the grid
         :param ds: The dataset to subset


### PR DESCRIPTION
1. From `xarray` v2023.10.0 onwards, the `reset_encoding` method was renamed to `drop_encoding`.   
So all previous versions will raise `AttributeError: 'Dataset' object has no attribute 'drop_encoding'`.  
Added xarray version in `pyproject.toml` dependencies to resolve this.  

2.  The Union operator ` | ` was introduced in python 3.10.  
Replaced `|` with `typing.Union` to add support for python 3.9 as well.  